### PR TITLE
pref: change openai max token length

### DIFF
--- a/promptulate/llms/openai/openai.py
+++ b/promptulate/llms/openai/openai.py
@@ -43,7 +43,7 @@ class BaseOpenAI(BaseLLM, ABC):
     """Penalizes repeated tokens."""
     n: int = 1
     """How many completions to generate for each prompt."""
-    max_tokens: int = 3000
+    max_tokens: int = -1
     """The maximum number of tokens to generate in the completion.
     -1 returns as many tokens as possible given the prompt and
     the models maximal context size."""
@@ -100,7 +100,7 @@ class OpenAI(BaseOpenAI):
     """Used to MessageSet data convert"""
     model: str = "text-davinci-003"
     """Model name to use."""
-    max_tokens: int = 800
+    max_tokens: int = -1
     """The maximum number of tokens to generate in the completion.
     -1 returns as many tokens as possible given the prompt and
     the models maximal context size."""


### PR DESCRIPTION
change: change openai max token length to -1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default token limit for AI-generated completions to allow for more flexible responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->