### PR TITLE
V1.11.0/add template jinja2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ OS := $(shell python -c "import sys; print(sys.platform)")
 
 ifeq ($(OS),win32)
 	PYTHONPATH := $(shell python -c "import os; print(os.getcwd())")
-    TEST_COMMAND := set PYTHONPATH=$(PYTHONPATH) && poetry run pytest -c pyproject.toml --cov-report=html --cov=promptulate ./tests/test_chat.py ./tests/output_formatter
+    TEST_COMMAND := set PYTHONPATH=$(PYTHONPATH) && poetry run pytest -c pyproject.toml --cov-report=html --cov=promptulate ./tests/test_chat.py ./tests/output_formatter ./tests/test_import.py ./tests/utils/test_string_template.py
 	TEST_PROD_COMMAND := set PYTHONPATH=$(PYTHONPATH) && poetry run pytest -c pyproject.toml --cov-report=html --cov=promptulate tests
 else
 	PYTHONPATH := `pwd`
-    TEST_COMMAND := PYTHONPATH=$(PYTHONPATH) poetry run pytest -c pyproject.toml --cov-report=html --cov=promptulate ./tests/test_chat.py ./tests/output_formatter
+    TEST_COMMAND := PYTHONPATH=$(PYTHONPATH) poetry run pytest -c pyproject.toml --cov-report=html --cov=promptulate ./tests/test_chat.py ./tests/output_formatter ./tests/test_import.py ./tests/utils/test_string_template.py
 	TEST_PROD_COMMAND := PYTHONPATH=$(PYTHONPATH) poetry run pytest -c pyproject.toml --cov-report=html --cov=promptulate tests
 endif
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
   <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/promptulate_logo_new.png"/>
 </p>
 
-
 # What is Promptulate?
 `Promptulate AI` focuses on building a developer platform for large language model applications, dedicated to providing developers and businesses with the ability to build, extend, and evaluate large language model applications. `Promptulate` is a large language model automation and application development framework under `Promptulate AI`, designed to help developers build industry-level large model applications at a lower cost. It includes most of the common components for application layer development in the LLM field, such as external tool components, model components, Agent intelligent agents, external data source integration modules, data storage modules, and lifecycle modules. With `Promptulate`, you can easily build your own LLM applications.
 
@@ -118,7 +117,7 @@ By following these principles and incorporating the latest advancements in artif
 Feel free to join the group chat to discuss topics related to large language models (LLM). If the link is expired, you can notify the author through an issue or email.
 
 <div style="width: 250px;margin: 0 auto;">
-    <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/20231211045023.png"/>
+    <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/20231219175857.png"/>
 </div>
 
 # Contributions

--- a/README_zh.md
+++ b/README_zh.md
@@ -121,7 +121,7 @@ promptulate框架的设计原则包括：模块化、可扩展性、互操作性
 欢迎加入群聊一起交流讨论有关LLM相关的话题，链接过期了可以issue或email提醒一下作者。
 
 <div style="width: 250px;margin: 0 auto;">
-    <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/20231211045023.png"/>
+    <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/20231219175857.png"/>
 </div>
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,7 @@ promptulate框架的设计原则包括：模块化、可扩展性、互操作性
 欢迎加入群聊一起交流讨论有关LLM相关的话题，链接过期了可以issue或email提醒一下作者。
 
 <div style="width: 250px;margin: 0 auto;">
-    <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/20231211045023.png"/>
+    <img src="https://zeeland-bucket.oss-cn-beijing.aliyuncs.com/images/20231219175857.png"/>
 </div>
 
 ## 贡献

--- a/docs/modules/other/string_template.md
+++ b/docs/modules/other/string_template.md
@@ -73,3 +73,45 @@ Begin!
 Question: Tell me a funny joke about chickens.
 Thought:
 ```
+
+## Jinja2
+In some cases, you will get error when you use single curly braces. For example, the following code will raise an error.
+
+```python
+from promptulate.utils import StringTemplate
+
+data = "test"
+prompt = "This is a {data} {'key': 'value'}"
+
+resp: str = StringTemplate(prompt).format(data=data)
+print(resp)
+```
+
+Output:
+
+```text
+Traceback (most recent call last):
+  File "/Users/xxx/PycharmProjects/promptulate/venv/lib/python3.8/site-packages/promptulate/utils/string_template.py", line 31, in format
+    return self.template.format(*args, **kwargs)
+KeyError: "'key'"
+```
+
+StringTemplate use f-string default, it will get error when facing `{'key':'value'}`. The follow example show how to use Jinja2 to avoid this error.
+
+```python
+from promptulate.utils import StringTemplate
+
+data = "test"
+prompt = """This is a {{data}} {'key': 'value'}"""
+
+resp: str = StringTemplate(prompt, template_format="jinja2").format(data=data)
+print(resp)
+```
+
+Output:
+
+```text
+This is a test {'key': 'value'}
+```
+
+**Therefore, you can use `{{variable}}` to avoid some potential problems by jinja2.**

--- a/promptulate/client/pne.py
+++ b/promptulate/client/pne.py
@@ -4,12 +4,17 @@ from promptulate.utils.color_print import print_text
 
 
 def main():
-    print_text("🌟 Welcome to Promptulate! 😀", "green")
-    print_text(f"Version: {version('promptulate')}", "blue")
-    print_text("Github repo: https://github.com/Undertone0809/promptulate", "blue")
     print_text(
-        "Official document: https://undertone0809.github.io/promptulate/#/", "blue"
+        "🌟 Welcome to Promptulate! Let's create something amazing together!😀", "green"
     )
+    print_text(f"Version: {version('promptulate')}", "blue")
+
+    prompt = """Explore the code and contribute on GitHub: 🔗 https://github.com/Undertone0809/promptulate
+Access the official documentation: 🔗 https://undertone0809.github.io/promptulate/#/
+Need help or have a question? Open an issue: 🔗 https://github.com/Undertone0809/promptulate/issues
+Join the development and contribute: 🔗 https://undertone0809.github.io/promptulate/#/other/contribution
+    """  # noqa: E501
+    print_text(prompt, "blue")
 
 
 if __name__ == "__main__":

--- a/promptulate/output_formatter/formatter.py
+++ b/promptulate/output_formatter/formatter.py
@@ -42,6 +42,11 @@ class OutputFormatter:
             pydantic_obj (type(BaseModel)): The Pydantic object to format.
             examples (List[BaseModel], optional): Examples of the Pydantic object.
         """
+        if not isinstance(pydantic_obj, type(BaseModel)):
+            raise ValueError(
+                f"pydantic_obj must be a Pydantic object. Got: {pydantic_obj}"
+            )
+
         self.pydantic_obj = pydantic_obj
         self.examples = examples
 

--- a/promptulate/utils/string_template.py
+++ b/promptulate/utils/string_template.py
@@ -1,19 +1,73 @@
 import re
 from typing import Any, List
 
+from typing_extensions import Literal
+
+
+def _get_jinja2_variables(template: str) -> List[str]:
+    try:
+        from jinja2 import Environment, meta
+    except ImportError:
+        raise ImportError(
+            "jinja2 not installed, which is needed to use the jinja2_formatter. "
+            "Please install it with `pip install jinja2`."
+        )
+    env = Environment()
+    ast = env.parse(template)
+    variables = meta.find_undeclared_variables(ast)
+    return list(variables)
+
+
+def _jinja2_format(template: str, **kwargs) -> str:
+    """Format a template using jinja2.
+
+    *Security warning*: As of LangChain 0.0.329, this method uses Jinja2's
+        SandboxedEnvironment by default. However, this sand-boxing should
+        be treated as a best-effort approach rather than a guarantee of security.
+        Do not accept jinja2 templates from untrusted sources as they may lead
+        to arbitrary Python code execution.
+
+        https://jinja.palletsprojects.com/en/3.1.x/sandbox/
+    """
+    try:
+        from jinja2.sandbox import SandboxedEnvironment
+    except ImportError:
+        raise ImportError(
+            "jinja2 not installed, which is needed to use the jinja2_formatter. "
+            "Please install it with `pip install jinja2`."
+            "Please be cautious when using jinja2 templates. "
+            "Do not expand jinja2 templates using unverified or user-controlled "
+            "inputs as that can result in arbitrary Python code execution."
+        )
+
+    # This uses a sandboxed environment to prevent arbitrary code execution.
+    # Jinja2 uses an opt-out rather than opt-in approach for sand-boxing.
+    # Please treat this sand-boxing as a best-effort approach rather than
+    # a guarantee of security.
+    # We recommend to never use jinja2 templates with untrusted inputs.
+    # https://jinja.palletsprojects.com/en/3.1.x/sandbox/
+    # approach not a guarantee of security.
+    return SandboxedEnvironment().from_string(template).render(**kwargs)
+
 
 class StringTemplate:
     """String Template for llm. It can generate a complex prompt."""
 
-    template: str
-    variables: List[str]
+    def __init__(
+        self, template: str, template_format: Literal["f-string", "jinja2"] = "f-string"
+    ):
+        self.template: str = template
+        self.template_format: str = template_format
+        self.variables: List[str] = []
 
-    def __init__(self, template: str):
-        self.template = template
-        self._fetch_variables()
-
-    def _fetch_variables(self):
-        self.variables = re.findall(r"\{(\w+)\}", self.template)
+        if template_format == "f-string":
+            self.variables = re.findall(r"\{(\w+)\}", self.template)
+        elif template_format == "jinja2":
+            self.variables = _get_jinja2_variables(template)
+        else:
+            raise ValueError(
+                f"template_format must be one of 'f-string' or 'jinja2'. Got: {template_format}"  # noqa: E501
+            )
 
     def format(self, params: List[Any] = None, **kwargs) -> str:
         """Enter variables and return the formatted string."""
@@ -22,4 +76,7 @@ class StringTemplate:
             for i, param in enumerate(params):
                 kwargs.update({self.variables[i]: param})
 
-        return self.template.format(**kwargs)
+        if self.template_format == "f-string":
+            return self.template.format(**kwargs)
+        elif self.template_format == "jinja2":
+            return _jinja2_format(self.template, **kwargs)

--- a/tests/output_formatter/test_formatter.py
+++ b/tests/output_formatter/test_formatter.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
+import pytest
 from pydantic import BaseModel, Field
 
 from promptulate.agents import BaseAgent
 from promptulate.llms import BaseLLM
-from promptulate.output_formatter import OutputFormatter
+from promptulate.output_formatter import OutputFormatter, formatting_result
 from promptulate.schema import BaseMessage, MessageSet
 
 
@@ -36,22 +37,22 @@ class AgentForTest(BaseAgent):
         return ""
 
 
-class Response(BaseModel):
+class LLMResponse(BaseModel):
     city: str = Field(description="City name")
     temperature: float = Field(description="Temperature in Celsius")
 
 
 def test_formatter_with_llm():
     llm = LLMForTest()
-    formatter = OutputFormatter(Response)
+    formatter = OutputFormatter(LLMResponse)
 
     prompt = (
         f"What is the temperature in Shanghai tomorrow? \n"
         f"{formatter.get_formatted_instructions()}"
     )
     llm_output = llm(prompt)
-    response: Response = formatter.formatting_result(llm_output)
-    assert isinstance(response, Response)
+    response: LLMResponse = formatter.formatting_result(llm_output)
+    assert isinstance(response, LLMResponse)
     assert isinstance(response.city, str)
     assert isinstance(response.temperature, float)
 
@@ -59,7 +60,31 @@ def test_formatter_with_llm():
 def test_formatter_with_agent():
     agent = AgentForTest()
     prompt = "What is the temperature in Shanghai tomorrow?"
-    response: Response = agent.run(prompt=prompt, output_schema=Response)
-    assert isinstance(response, Response)
+    response: LLMResponse = agent.run(prompt=prompt, output_schema=LLMResponse)
+    assert isinstance(response, LLMResponse)
     assert isinstance(response.city, str)
     assert isinstance(response.temperature, float)
+
+
+def test_init_outputformatter_with_error_pydantic_type():
+    """Test the error when the pydantic_obj of OutputFormatter is not a Pydantic
+    object."""
+
+    with pytest.raises(ValueError) as excinfo:
+        OutputFormatter("test")
+
+    assert "pydantic_obj must be a Pydantic object" in str(excinfo.value)
+
+
+def test_formatting_result_with_error_llm_output():
+    """Test the error when the llm_output of formatting_result is not a valid
+    json."""
+
+    from promptulate.error import OutputParserError
+
+    with pytest.raises(OutputParserError) as excinfo:
+        formatting_result(LLMResponse, "test")
+
+    assert f"Failed to parse {LLMResponse.__name__} from completion test." in str(
+        excinfo.value
+    )

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,30 @@
+def test_import_utils():
+    from promptulate.utils import (
+        StringTemplate,
+        enable_log,
+        export_openai_key_pool,
+        logger,
+    )
+
+
+def test_import_output_formatter():
+    from promptulate.output_formatter import OutputFormatter
+
+
+def test_import_promptulate():
+    from promptulate import (
+        AssistantMessage,
+        BaseAgent,
+        BaseLLM,
+        BaseMessage,
+        BaseTool,
+        ChatOpenAI,
+        MessageSet,
+        SystemMessage,
+        Tool,
+        ToolAgent,
+        UserMessage,
+        WebAgent,
+        chat,
+        define_tool,
+    )

--- a/tests/utils/test_string_template.py
+++ b/tests/utils/test_string_template.py
@@ -1,0 +1,23 @@
+from promptulate.utils.string_template import StringTemplate
+
+
+def test_f_string():
+    data = "Test"
+    prompt = """This is a {data}"""
+    string_template = StringTemplate(prompt)
+    resp = string_template.format(data=data)
+    assert resp == "This is a Test"
+
+    resp = string_template.format([data])
+    assert resp == "This is a Test"
+
+
+def test_jinja():
+    data = "Test"
+    prompt = """This is a {{data}} {fake} {'key':'value'}."""
+    string_template = StringTemplate(prompt, template_format="jinja2")
+    resp = string_template.format(data=data)
+    assert resp == "This is a Test {fake} {'key':'value'}."
+
+    resp = string_template.format([data])
+    assert resp == "This is a Test {fake} {'key':'value'}."


### PR DESCRIPTION
## Jinja2
In some cases, you will get error when you use single curly braces. For example, the following code will raise an error.

```python
from promptulate.utils import StringTemplate

data = "test"
prompt = "This is a {data} {'key': 'value'}"

resp: str = StringTemplate(prompt).format(data=data)
print(resp)
```

Output:

```text
Traceback (most recent call last):
  File "/Users/xxx/PycharmProjects/promptulate/venv/lib/python3.8/site-packages/promptulate/utils/string_template.py", line 31, in format
    return self.template.format(*args, **kwargs)
KeyError: "'key'"
```

StringTemplate use f-string default, it will get error when facing `{'key':'value'}`. The follow example show how to use Jinja2 to avoid this error.

```python
from promptulate.utils import StringTemplate

data = "test"
prompt = """This is a {{data}} {'key': 'value'}"""

resp: str = StringTemplate(prompt, template_format="jinja2").format(data=data)
print(resp)
```

Output:

```text
This is a test {'key': 'value'}
```

**Therefore, you can use `{{variable}}` to avoid some potential problems by jinja2.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search functionality integrated into the app interface.
  - Enhanced test coverage and support for additional test files.
  - Updated documentation images and added examples for template syntax usage.
  - Improved user feedback messages in the command-line interface.
  - Added input validation for formatting operations.

- **Bug Fixes**
  - Fixed an issue with the template formatting that could cause errors with certain syntax.

- **Documentation**
  - Updated image sources in documentation files.
  - Added new section on template syntax with examples in the documentation.

- **Tests**
  - Expanded test suite to include new test cases for import functionality and string template formatting.
  - Renamed classes and added error handling tests in the output formatter module.

- **Chores**
  - Updated `Makefile` to extend test commands for better platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->