### PR TITLE
pref: add proxies kwargs in duckduckgo tool run func

### DIFF
--- a/promptulate/tools/duckduckgo/api_wrapper.py
+++ b/promptulate/tools/duckduckgo/api_wrapper.py
@@ -10,7 +10,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
     safe_search: str = "moderate"
     time: Optional[str] = "y"
     max_num_of_results: int = 5
-
+    proxies: Optional[str] = None
     class Config:
         """Configuration for this pydantic object."""
 
@@ -37,7 +37,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
         if not num_results:
             num_results = self.max_num_of_results
 
-        with DDGS() as ddgs:
+        with DDGS(self.proxies) as ddgs:
             results = ddgs.text(
                 keyword,
                 region=self.region,
@@ -74,7 +74,7 @@ class DuckDuckGoSearchAPIWrapper(BaseModel):
         if not num_results:
             num_results = self.max_num_of_results
 
-        with DDGS() as ddgs:
+        with DDGS(self.proxies) as ddgs:
             results = ddgs.text(
                 query,
                 region=self.region,

--- a/promptulate/tools/duckduckgo/tools.py
+++ b/promptulate/tools/duckduckgo/tools.py
@@ -34,7 +34,9 @@ class DuckDuckGoTool(Tool):
             result_type="original"
         """
         from duckduckgo_search.exceptions import RateLimitException
-
+        if "proxies" in kwargs:
+            if kwargs["proxies"]:
+                self.api_wrapper.proxies = kwargs["proxies"]
         attempt = 0
         while attempt < self.max_retry:
             try:
@@ -80,6 +82,9 @@ class DuckDuckGoReferenceTool(Tool):
             default is string. Return List[Dict[str, str]] type data if you pass
             result_type="original"
         """
+        if "proxies" in kwargs:
+            if kwargs["proxies"]:
+                self.api_wrapper.proxies = kwargs["proxies"]
         result = self.api_wrapper.query_by_formatted_results(keyword, **kwargs)
         if "return_type" in kwargs and kwargs["return_type"] == "original":
             return result


### PR DESCRIPTION
.. add proxies kwargs in duckduckgo tool
tool.run(xxx,proxies="socks5://localhost:7891")
..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added proxy support for DuckDuckGo search queries, allowing users to route requests through specified proxies for enhanced privacy and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->