### PR TITLE
fix: ddg depc error in webagent

### DIFF
--- a/promptulate/client/chat.py
+++ b/promptulate/client/chat.py
@@ -34,7 +34,6 @@ from promptulate.tools import (
     DuckDuckGoTool,
     HumanFeedBackTool,
     PythonREPLTool,
-    SleepTool,
 )
 from promptulate.tools.shell import ShellTool
 from promptulate.utils.color_print import print_text
@@ -46,7 +45,6 @@ TOOL_MAPPING = {
     "WebSearch": DuckDuckGoTool,
     "Python Script Executor": PythonREPLTool,
     "Arxiv Query": ArxivQueryTool,
-    "Sleep": SleepTool,
     "Shell Executor": ShellTool,
     "HumanFeedBackTool": HumanFeedBackTool,
 }
@@ -173,6 +171,8 @@ def chat():
         llm = ChatOpenAI(model=model, temperature=0.0)
     elif "ernie" in model:
         llm = ErnieBot(model=model, temperature=0.1)
+    else:
+        raise ValueError(f"model {model} is not supported.")
 
     if terminal_mode == "Simple Chat":
         simple_chat(llm)

--- a/promptulate/tools/duckduckgo/tools.py
+++ b/promptulate/tools/duckduckgo/tools.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from promptulate.tools.base import Tool
 from promptulate.tools.duckduckgo.api_wrapper import DuckDuckGoSearchAPIWrapper
@@ -16,8 +16,12 @@ class DuckDuckGoTool(Tool):
         "Args : keyword(str)"
         "Input should be a search query."
     )
-    api_wrapper: DuckDuckGoSearchAPIWrapper = DuckDuckGoSearchAPIWrapper()
-    max_retry: int = 5
+
+    def __init__(self, max_retry: Optional[int] = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.max_retry: int = max_retry or 5
+        self.api_wrapper = DuckDuckGoSearchAPIWrapper()
 
     def _run(self, keyword: str, **kwargs) -> Union[str, List[str]]:
         """Run duckduckgo search and get search result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A powerful LLM Application development framework."
 name = "promptulate"
 readme = "README.md"
 repository = "https://github.com/Undertone0809/promptulate"
-version = "1.15.1"
+version = "1.15.2"
 keywords = [
     "promptulate",
     "pne",


### PR DESCRIPTION

error message when create a new environment
```
D:\Application\Conda\envs\uacp\python.exe D:\Projects\uacp\examples\assistant-agent\main.py 
Traceback (most recent call last):
  File "D:\Projects\uacp\examples\assistant-agent\main.py", line 4, in <module>
    from promptulate import ChatOpenAI
  File "D:\Application\Conda\envs\uacp\lib\site-packages\promptulate\__init__.py", line 24, in <module>
    from promptulate.agents.web_agent.agent import WebAgent
  File "D:\Application\Conda\envs\uacp\lib\site-packages\promptulate\agents\web_agent\agent.py", line 3, in <module>
    from promptulate.tools.duckduckgo.tools import ddg_websearch
  File "D:\Application\Conda\envs\uacp\lib\site-packages\promptulate\tools\duckduckgo\__init__.py", line 1, in <module>
    from promptulate.tools.duckduckgo.tools import (
  File "D:\Application\Conda\envs\uacp\lib\site-packages\promptulate\tools\duckduckgo\tools.py", line 9, in <module>
    class DuckDuckGoTool(Tool):
  File "D:\Application\Conda\envs\uacp\lib\site-packages\promptulate\tools\duckduckgo\tools.py", line 19, in DuckDuckGoTool
    api_wrapper: DuckDuckGoSearchAPIWrapper = DuckDuckGoSearchAPIWrapper()
  File "D:\Application\Conda\envs\uacp\lib\site-packages\pydantic\v1\main.py", line 341, in __init__
    raise validation_error
pydantic.v1.error_wrappers.ValidationError: 1 validation error for DuckDuckGoSearchAPIWrapper
__root__
  Could not import duckduckgo-search python package. Please install it with `pip install duckduckgo-search`. (type=value_error)

Process finished with exit code 1

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `DuckDuckGoTool` now allows customization of retry attempts with a default set to 5.

- **Changes**
	- Updated the app version to 1.15.2.

- **Removed**
	- Removed the `SleepTool` from the chat module.

- **Bug Fixes**
	- Ensured an exception is raised if an unsupported model is used in the chat module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->