### PR TITLE
Add retry mechanism to LLMFactory and BaseLLM

### DIFF
--- a/promptulate/chat.py
+++ b/promptulate/chat.py
@@ -44,6 +44,7 @@ def _get_llm(
     model: Optional[str] = None,
     model_config: Optional[dict] = None,
     custom_llm: Optional[BaseLLM] = None,
+    max_retry: int = 5,
 ) -> BaseLLM:
     """Get LLM instance.
 
@@ -51,6 +52,7 @@ def _get_llm(
         model(str): LLM model.
         model_config(dict): LLM model config.
         custom_llm(BaseLLM): custom LLM instance.
+        max_retry(int): Maximum number of retries.
 
     Returns:
         Return LLM instance.
@@ -69,7 +71,7 @@ def _get_llm(
     if custom_llm:
         return custom_llm
 
-    return LLMFactory.build(model, model_config=model_config)
+    return LLMFactory.build(model, model_config=model_config, max_retry=max_retry)
 
 
 class AIChat:
@@ -81,6 +83,7 @@ class AIChat:
         custom_llm: Optional[BaseLLM] = None,
         enable_plan: bool = False,
         enable_memory: bool = False,
+        max_retry: int = 5,
     ):
         """Initialize the AIChat.
 
@@ -92,8 +95,9 @@ class AIChat:
             custom_llm(Optional[BaseLLM]): custom LLM instance.
             enable_plan(bool): use Agent with plan ability if True.
             enable_memory(bool): enable memory if True.
+            max_retry(int): Maximum number of retries.
         """
-        self.llm: BaseLLM = _get_llm(model, model_config, custom_llm)
+        self.llm: BaseLLM = _get_llm(model, model_config, custom_llm, max_retry)
         self.tools: Optional[List[ToolTypes]] = tools
         self.agent: Optional[BaseAgent] = None
 
@@ -207,6 +211,7 @@ def chat(
     custom_llm: Optional[BaseLLM] = None,
     enable_plan: bool = False,
     stream: bool = False,
+    max_retry: int = 5,
     **kwargs,
 ) -> Union[str, BaseMessage, T, List[BaseMessage], StreamIterator]:
     """A universal chat method, you can chat any model like OpenAI completion.
@@ -226,6 +231,7 @@ def chat(
         custom_llm(BaseLLM): You can use custom LLM if you have.
         enable_plan(bool): use Agent with plan ability if True.
         stream(bool): return stream iterator if True.
+        max_retry(int): Maximum number of retries.
         **kwargs: litellm kwargs
 
     Returns:
@@ -240,6 +246,7 @@ def chat(
         tools=tools,
         custom_llm=custom_llm,
         enable_plan=enable_plan,
+        max_retry=max_retry,
     ).run(
         messages=messages,
         output_schema=output_schema,

--- a/promptulate/llms/_litellm.py
+++ b/promptulate/llms/_litellm.py
@@ -31,40 +31,49 @@ def parse_content(chunk) -> (str, str):
 
 
 class LiteLLM(BaseLLM):
-    def __init__(self, model: str, model_config: Optional[dict] = None, **kwargs):
+    def __init__(self, model: str, model_config: Optional[dict] = None, max_retry: int = 5, **kwargs):
         logger.info(f"[pne chat] init LiteLLM, model: {model} config: {model_config}")
         super().__init__(**kwargs)
         self._model: str = model
         self._model_config: dict = model_config or {}
+        self.max_retry: int = max_retry
 
     def _predict(
         self, messages: MessageSet, stream: bool = False, *args, **kwargs
     ) -> Union[AssistantMessage, StreamIterator]:
         logger.info(f"[pne chat] prompts: {messages.string_messages}")
-        temp_response = litellm.completion(
-            model=self._model,
-            messages=messages.listdict_messages,
-            **self._model_config,
-            stream=stream,
-        )
+        retry_count = 0
+        while retry_count < self.max_retry:
+            try:
+                temp_response = litellm.completion(
+                    model=self._model,
+                    messages=messages.listdict_messages,
+                    **self._model_config,
+                    stream=stream,
+                )
 
-        if stream:
-            return StreamIterator(
-                response_stream=temp_response,
-                parse_content=parse_content,
-                return_raw_response=False,
-            )
+                if stream:
+                    return StreamIterator(
+                        response_stream=temp_response,
+                        parse_content=parse_content,
+                        return_raw_response=False,
+                    )
 
-        response = AssistantMessage(
-            content=temp_response.choices[0].message.content,
-            additional_kwargs=temp_response.json()
-            if isinstance(temp_response.json(), dict)
-            else json.loads(temp_response.json()),
-        )
-        logger.debug(
-            f"[pne chat] response: {json.dumps(response.additional_kwargs, indent=2)}"
-        )
-        return response
+                response = AssistantMessage(
+                    content=temp_response.choices[0].message.content,
+                    additional_kwargs=temp_response.json()
+                    if isinstance(temp_response.json(), dict)
+                    else json.loads(temp_response.json()),
+                )
+                logger.debug(
+                    f"[pne chat] response: {json.dumps(response.additional_kwargs, indent=2)}"
+                )
+                return response
+            except Exception as e:
+                logger.error(f"[pne chat] Error during prediction: {e}")
+                retry_count += 1
+                if retry_count >= self.max_retry:
+                    raise e
 
     def __call__(self, instruction: str, *args, **kwargs) -> str:
         return self._predict(

--- a/promptulate/llms/factory.py
+++ b/promptulate/llms/factory.py
@@ -7,7 +7,7 @@ from promptulate.llms.base import BaseLLM
 class LLMFactory:
     @classmethod
     def build(
-        cls, model_name: str, *, model_config: Optional[Dict[str, Any]] = None, **kwargs
+        cls, model_name: str, *, model_config: Optional[Dict[str, Any]] = None, max_retry: int = 5, **kwargs
     ) -> BaseLLM:
         model_config = model_config or {}
 
@@ -17,12 +17,12 @@ class LLMFactory:
             if provider == "zhipu":
                 from promptulate.llms import ZhiPu
 
-                return ZhiPu(model=model_id, model_config=model_config, **kwargs)
+                return ZhiPu(model=model_id, model_config=model_config, max_retry=max_retry, **kwargs)
             elif provider == "qianfan":
                 from promptulate.llms import QianFan
 
-                return QianFan(model=model_id, model_config=model_config, **kwargs)
+                return QianFan(model=model_id, model_config=model_config, max_retry=max_retry, **kwargs)
         except ValueError:
             pass
 
-        return LiteLLM(model=model_name, model_config=model_config, **kwargs)
+        return LiteLLM(model=model_name, model_config=model_config, max_retry=max_retry, **kwargs)

--- a/tests/llms/test_factory.py
+++ b/tests/llms/test_factory.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 import promptulate as pne
+from promptulate.llms._litellm import LiteLLM
 
 
 def test_init_litellm():
@@ -58,3 +59,19 @@ def test_call(mock_post, llm_factory, mock_response):
     result = llm_factory(prompt)
     assert result is not None
     assert "[start] This is a test [end]" in result
+
+
+def test_retry_mechanism():
+    with mock.patch.object(LiteLLM, "_predict", side_effect=Exception("Test error")) as mock_predict:
+        model = pne.LLMFactory.build(model_name="gpt-4-turbo", max_retry=3)
+        with pytest.raises(Exception, match="Test error"):
+            model("hello")
+        assert mock_predict.call_count == 3
+
+
+def test_litellm_retry():
+    with mock.patch.object(LiteLLM, "_predict", side_effect=Exception("Test error")) as mock_predict:
+        model = pne.LLMFactory.build(model_name="gpt-4-turbo", max_retry=5)
+        with pytest.raises(Exception, match="Test error"):
+            model("hello")
+        assert mock_predict.call_count == 5


### PR DESCRIPTION
Related to #651

Add retry mechanism to `LLMFactory` and `LiteLLM` classes to increase robustness.

* **LLMFactory**:
  - Add `max_retry` parameter to `LLMFactory.build` method in `promptulate/llms/factory.py`.
  - Pass `max_retry` parameter to `LiteLLM` constructor.

* **LiteLLM**:
  - Add `max_retry` attribute to `LiteLLM` class in `promptulate/llms/_litellm.py`.
  - Modify `_predict` method to include retry logic.

* **AIChat**:
  - Add `max_retry` parameter to `AIChat` constructor in `promptulate/chat.py`.
  - Pass `max_retry` parameter to `LLMFactory.build` method.

* **Tests**:
  - Add tests in `tests/llms/test_factory.py` to verify retry mechanism.
  - Mock `LiteLLM` to simulate failure and retry behavior.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Undertone0809/promptulate/issues/651?shareId=2bba3c3e-425f-43ee-bf59-121cd5ec418d).