### PR TITLE
Add stream output for Agent

### DIFF
--- a/example/agent/tool_agent_usage.py
+++ b/example/agent/tool_agent_usage.py
@@ -10,7 +10,8 @@ def main():
     model = pne.LLMFactory.build(model_name="gpt-4-1106-preview")
     agent = pne.ToolAgent(tools=tools, llm=model)
     prompt = """Who is Leo DiCaprio's girlfriend? What is her current age raised to the 0.43 power?"""  # noqa
-    agent.run(prompt)
+    for response in agent.run(prompt, stream=True):
+        print(response)
 
 
 if __name__ == "__main__":

--- a/promptulate/agents/tool_agent/agent.py
+++ b/promptulate/agents/tool_agent/agent.py
@@ -119,13 +119,14 @@ class ToolAgent(BaseAgent):
         return f"Current date: {time.strftime('%Y-%m-%d %H:%M:%S')}"
 
     def _run(
-        self, instruction: str, return_raw_data: bool = False, **kwargs
+        self, instruction: str, return_raw_data: bool = False, stream: bool = False, **kwargs
     ) -> Union[str, ActionResponse]:
         """Run the tool agent. The tool agent will interact with the LLM and the tool.
 
         Args:
             instruction(str): The instruction to the tool agent.
             return_raw_data(bool): Whether to return raw data. Default is False.
+            stream(bool): Whether to enable streaming output. Default is False.
 
         Returns:
             The output of the tool agent.
@@ -173,6 +174,9 @@ class ToolAgent(BaseAgent):
                 HookTable.ON_AGENT_OBSERVATION, self, observation=tool_result
             )
             self.conversation_prompt += f"Observation: {tool_result}\n"
+
+            if stream:
+                yield tool_result
 
             iterations += 1
             used_time += time.time() - start_time

--- a/tests/agents/test_tool_agent.py
+++ b/tests/agents/test_tool_agent.py
@@ -53,3 +53,12 @@ def test_init_by_tool_and_kit():
     llm = FakeLLM()
     agent = ToolAgent(llm=llm, tools=[MockToolKit(), fake_tool_1, fake_tool_2])
     assert len(agent.tool_manager.tools) == 4
+
+
+def test_stream_mode():
+    llm = FakeLLM()
+    agent = ToolAgent(llm=llm, tools=[fake_tool_1, fake_tool_2])
+    prompt = "What is the temperature in Shanghai?"
+    responses = list(agent.run(prompt, stream=True))
+    assert len(responses) > 0
+    assert all(isinstance(response, str) for response in responses)


### PR DESCRIPTION
Related to #833

Add stream mode output to ToolAgent.

* Modify `promptulate/agents/tool_agent/agent.py` to add a `stream` parameter to the `run` method and implement logic to handle streaming output.
* Update `example/agent/tool_agent_usage.py` to demonstrate the usage of `agent.run(..., stream=True)`.
* Add tests in `tests/agents/test_tool_agent.py` to verify the stream mode output functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Undertone0809/promptulate/issues/833?shareId=cf7fcc11-f88a-45e4-b14f-9ea081a665d8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced real-time streaming responses for the tool agent, enhancing interactivity and responsiveness when executing commands.
  
- **Bug Fixes**
	- Improved the `_run` method to allow optional streaming output, ensuring better responsiveness during LLM interactions.

- **Tests**
	- Added a new test to evaluate the tool agent's functionality in stream mode, increasing test coverage for new streaming capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->